### PR TITLE
Allow to measure wall-clock time

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Use `--help` to list command-line options.
 
 * `--time-mode`
 
-  Whether to measure CPU time ("cpu") or wall-clock time ("wall-clock") (default: cpu)
+  Whether to measure CPU time ("cpu") or wall-clock time ("wall") (default: cpu)
 
 * `+RTS -T`
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ watch videos while waiting for benchmarks to finish. That's the cause
 of a notorious "variance introduced by outliers: 88% (severely inflated)" warning.
 
 To alleviate this issue `tasty-bench` measures CPU time by `getCPUTime`
-instead of wall-clock time.
+instead of wall-clock time by default.
 It does not provide a perfect isolation from other processes (e. g.,
 if CPU cache is spoiled by others, populating data back from RAM
 is your burden), but is a bit more stable.
@@ -163,6 +163,9 @@ Caveat: this means that for multithreaded algorithms
 `criterion` and `gauge` print maximum of core's wall-clock time.
 It also means that `tasty-bench` cannot measure time spent out of process,
 e. g., calls to other executables.
+
+You have the option to measure wall-clock time instead, using the
+`TimeMode` tasty option or the `--time-mode` CLI flag.
 
 ## Statistical model
 
@@ -602,6 +605,10 @@ Use `--help` to list command-line options.
 * `--svg`
 
   File to plot results in SVG format.
+
+* `--time-mode`
+
+  Whether to measure CPU time ("cpu") or wall-clock time ("wall-clock") (default: cpu)
 
 * `+RTS -T`
 

--- a/src/Test/Tasty/Bench.hs
+++ b/src/Test/Tasty/Bench.hs
@@ -554,7 +554,7 @@ Use @--help@ to list command-line options.
 [@--time-mode@]:
 
     Whether to measure CPU time ("cpu") or wall-clock time
-    ("wall-clock") (default: cpu)
+    ("wall") (default: cpu)
 
 [@+RTS@ @-T@]:
 
@@ -818,14 +818,14 @@ instance IsOption TimeMode where
   defaultValue = CpuTime
   parseValue v = case v of
     "cpu" -> Just CpuTime
-    "wall-clock" -> Just WallTime
+    "wall" -> Just WallTime
     _ -> Nothing
   optionName = pure "time-mode"
-  optionHelp = pure "Whether to measure CPU time (\"cpu\") or wall-clock time (\"wall-clock\")"
+  optionHelp = pure "Whether to measure CPU time (\"cpu\") or wall-clock time (\"wall\")"
 #if MIN_VERSION_tasty(1,3,0)
   showDefaultValue m = Just $ case m of
     CpuTime -> "cpu"
-    WallTime -> "wall-clock"
+    WallTime -> "wall"
 #endif
 #endif
 

--- a/tasty-bench.cabal
+++ b/tasty-bench.cabal
@@ -63,6 +63,9 @@ library
   if impl(ghc < 7.8)
     build-depends:
       tagged >= 0.2
+  if impl(ghc < 8.4)
+    build-depends:
+      clock >= 0.4
 
   if flag(debug)
     cpp-options: -DDEBUG

--- a/tasty-bench.cabal
+++ b/tasty-bench.cabal
@@ -63,9 +63,6 @@ library
   if impl(ghc < 7.8)
     build-depends:
       tagged >= 0.2
-  if impl(ghc < 8.4)
-    build-depends:
-      clock >= 0.4
 
   if flag(debug)
     cpp-options: -DDEBUG


### PR DESCRIPTION
Closes #23 

---

**This description is now outdated after the review comments below**

For measuring monotonic time, I went with `getMonotonicTimeNSec` on `GHC >=8.4`, and `getTime Monotonic` from `clock` for older GHCs. I didn't go with tasty's `getTime` as we have to have an alternative for the `tasty: False` flag either way.

Also, the note

> If you find yourself in an environment, where `tasty` is not available and you
> have access to boot packages only, you can still use `tasty-bench`!

is now only true on GHC >=8.4 (due to the new dependency on `clock` on GHC <8.4). If supporting this workflow on GHC <8.4 is desired, we could either disable the wall-clock functionality in this case, or fall back to using non-monotonic measurements from `time`.