### PR TITLE
performMinorGC before collecting end RTSStats

### DIFF
--- a/src/Test/Tasty/Bench.hs
+++ b/src/Test/Tasty/Bench.hs
@@ -1105,6 +1105,7 @@ measure timeMode n (Benchmarkable act) = do
   (startAllocs, startCopied, startMaxMemInUse) <- getAllocsAndCopied
   act n
   endTime <- getTimePicoSecs'
+  performMinorGC -- perform GC to update RTSStats
   (endAllocs, endCopied, endMaxMemInUse) <- getAllocsAndCopied
   let meas = Measurement
         { measTime   = endTime - startTime


### PR DESCRIPTION
RTSStats are updated on GC, so this ensures that the collected memory stats are accurate.

Fixes #62.