### PR TITLE
Add CustomTime time mode

### DIFF
--- a/src/Test/Tasty/Bench.hs
+++ b/src/Test/Tasty/Bench.hs
@@ -949,9 +949,11 @@ instance IsOption TimeMode where
   parseValue v = case v of
     "cpu" -> Just CpuTime
     "wall" -> Just WallTime
+    "mutcpu" -> Just mutatorCpuTime
+    "mutwall" -> Just mutatorWallTime
     _ -> Nothing
   optionName = pure "time-mode"
-  optionHelp = pure "Whether to measure CPU time (\"cpu\") or wall-clock time (\"wall\")"
+  optionHelp = pure "Whether to measure total CPU time (\"cpu\"), total wall-clock time (\"wall\"), or time spent by the mutator (CPU \"mutcpu\" or wall-clock \"mutwall\")"
   showDefaultValue m = case m of
     CpuTime -> Just "cpu"
     WallTime -> Just "wall"


### PR DESCRIPTION
This option allows users to supply their own time function. (My use case is to get mutator time from the RTS.)

Addresses #60 minus the sub-issue of preventing breaking changes in the future if this option is not general enough.