### PR TITLE
Add benchWith to benchmark inside a larger action

### DIFF
--- a/src/Test/Tasty/Bench.hs
+++ b/src/Test/Tasty/Bench.hs
@@ -716,7 +716,7 @@ import Control.Applicative
 import Control.Arrow (first, second)
 import Control.DeepSeq (NFData, force, rnf)
 import Control.Exception (bracket, bracket_, evaluate)
-import Control.Monad (void, unless, guard, (>=>), when)
+import Control.Monad (void, unless, guard, join, (>=>), when)
 import Data.Data (Data)
 import Data.Foldable (foldMap, traverse_)
 import Data.Int (Int64)
@@ -1356,7 +1356,9 @@ instance IsTest BenchmarkableWith where
     let run' :: Benchmarkable -> IO ()
         run' b = do
             r <- run opts b yieldProgress
-            writeIORef rr $ Just r
+            join . atomicModifyIORef' rr $ \prev -> case prev of
+                Nothing -> (Just r, pure ())
+                p -> (p, error "Benchmarkable called multiple times")
     bracketedBenchmark run'
     maybeRes <- readIORef rr
     pure $ case maybeRes of

--- a/src/Test/Tasty/Bench.hs
+++ b/src/Test/Tasty/Bench.hs
@@ -671,7 +671,7 @@ module Test.Tasty.Bench
   , Benchmark
   , bench
   , bgroup
-  , benchWith
+  , benchCont
   , bcompare
   , bcompareWithin
   , env
@@ -717,6 +717,7 @@ import Control.Arrow (first, second)
 import Control.DeepSeq (NFData, force, rnf)
 import Control.Exception (bracket, bracket_, evaluate)
 import Control.Monad (void, unless, guard, join, (>=>), when)
+import Control.Monad.Trans.Cont
 import Data.Data (Data)
 import Data.Foldable (foldMap, traverse_)
 import Data.Int (Int64)
@@ -1317,12 +1318,12 @@ bgroup = testGroup
 -- >     benchmarkWrites
 --
 -- This benchmarks writes to a closed file handle, which will not go well.
--- Instead, @benchWith@ allows you to embed a t'Benchmarkable' inside your context.
--- As a trivial example,
+-- Instead, @benchCont@ allows you to embed a t'Benchmarkable'
+-- in a continuation. As a trivial example,
 --
 -- > main :: IO ()
 -- > main = defaultMain
--- >   [ benchWith "write syscall" $ benchmarkWrites ]
+-- >   [ benchCont "write syscall" $ ContT benchmarkWrites ]
 -- >
 -- > benchmarkWrites :: (Benchmarkable -> IO ()) -> IO ()
 -- > benchmarkWrites runBenchmark = withBinaryFile "/dev/null" WriteMode $ \fh -> do
@@ -1338,20 +1339,12 @@ bgroup = testGroup
 -- Create a separate 'Benchmark' instead.
 --
 -- @since 0.6
-benchWith :: String -> ((Benchmarkable -> IO ()) -> IO ()) -> Benchmark
-benchWith name = singleTest name . BenchmarkableWith
+benchCont :: String -> ContT () IO Benchmarkable -> Benchmark
+benchCont = singleTest
 
--- | @since 0.6
-newtype BenchmarkableWith = BenchmarkableWith
-  { unBenchmarkableWith :: (Benchmarkable -> IO ()) -> IO ()
-  }
-  deriving
-  ( Generic
-  )
-
-instance IsTest BenchmarkableWith where
+instance IsTest (ContT () IO Benchmarkable) where
   testOptions = pure benchOptions
-  run opts (BenchmarkableWith bracketedBenchmark) yieldProgress = do
+  run opts (ContT bracketedBenchmark) yieldProgress = do
     rr <- newIORef Nothing
     let run' :: Benchmarkable -> IO ()
         run' b = do
@@ -1362,7 +1355,7 @@ instance IsTest BenchmarkableWith where
     bracketedBenchmark run'
     maybeRes <- readIORef rr
     pure $ case maybeRes of
-        Nothing -> testFailed "Provided action didn't run a Benchmarkable"
+        Nothing -> testFailed "Provided ContT didn't run the passed Benchmarkable"
         Just r -> r
 
 -- | Compare benchmarks, reporting relative speed up or slow down.

--- a/tasty-bench.cabal
+++ b/tasty-bench.cabal
@@ -46,7 +46,8 @@ library
 
   build-depends:
     base >= 4.9 && < 5,
-    deepseq >= 1.1 && < 1.6
+    deepseq >= 1.1 && < 1.6,
+    transformers >= 0.4 && < 0.7
   if impl(ghc < 9.0)
     build-depends:
       ghc-prim < 0.14


### PR DESCRIPTION
`withResource` or `env` are preferred, but not always possible. Consider situations where a library only exposes resources via bracket-style continuation passing, and you don't want to benchmark acquiring and releasing said resource.